### PR TITLE
Kwicks turned responsive - widths as % of container.

### DIFF
--- a/jquery.kwicks.js
+++ b/jquery.kwicks.js
@@ -29,7 +29,8 @@
 				throw new Error('Kwicks option "maxSize" may not be less than "size"');
 			if (o.behavior && o.behavior !== 'menu')
 				throw new Error('Unrecognized Kwicks behavior specified: ' + o.behavior);
-			
+			if (o.units && o.units !== 'px' && o.units !== '%')
+				throw new Error('Unrecognized units specified (not px or % ): ' + o.units);
 			return this.each(function() {
 				$(this).data('kwicks', new Kwick(this, o));
 			});
@@ -157,6 +158,8 @@
 
 		// calculate minSize from maxSize or vice versa
 		var numPanels = this.$panels.length;
+		if (typeof opts.units === 'undefined') {
+			opts.units = 'px';
 		if (typeof opts.minSize === 'undefined') {
 			opts.minSize = ((opts.size * numPanels) - opts.maxSize) / (numPanels - 1);
 		} else {
@@ -244,11 +247,12 @@
 			pAlign = this.primaryAlignment,
 			sAlign = this.secondaryAlignment,
 			spacing = this.opts.spacing;
-
+			units = this.opts.units;
+			
 		// grab and cache the the size or our container's primary dimension
 		var containerSize = this._containerSize;
 		if (!containerSize) {
-			containerSize = this._containerSize = this.$container.css(pDim).replace('px', '');
+			containerSize = this._containerSize = this.$container.css(pDim).replace(units, '');
 		}
 
 		// the kwicks-processed class ensures that panels are absolutely positioned, but on our
@@ -265,10 +269,10 @@
 			offset = Math.round(offsets[i]);
 			if (i === $panels.length - 1) {
 				size = containerSize - offset;
-				style = sAlign + ':0;' + pDim + ':' + size + 'px;';
+				style = sAlign + ':0;' + pDim + ':' + size + units + ";";
 			} else {
 				size = prevOffset - offset - spacing;
-				style = pAlign + ':' + offset + 'px;' + pDim + ':' + size + 'px;';
+				style = pAlign + ':' + offset + units + ';' + pDim + ':' + size + units + ';';
 			}
 			this.setStyle($panels[i], stylePrefix + style);
 		}

--- a/jquery.kwicks.js
+++ b/jquery.kwicks.js
@@ -160,6 +160,7 @@
 		var numPanels = this.$panels.length;
 		if (typeof opts.units === 'undefined') {
 			opts.units = 'px';
+		}
 		if (typeof opts.minSize === 'undefined') {
 			opts.minSize = ((opts.size * numPanels) - opts.maxSize) / (numPanels - 1);
 		} else {

--- a/jquery.kwicks.js
+++ b/jquery.kwicks.js
@@ -180,7 +180,6 @@
 			if (typeof opts.minSize === 'undefined') {
 				opts.maxSize = Math.round( 1000 * opts.maxSize / opts.size ) / 10; // expanded image size relative to 100% container
 				opts.minSize = Math.round( ((100 - opts.maxSize - (numPanels - 1) * opts.spacing) / (numPanels - 1)) * 10 ) / 10; // contracted image size
-				opts.size = Math.round( 1000 / numPanels - 1 ) / 10;
 			} else {
 				opts.minSize = Math.round( 10 * opts.minSize / opts.size ) / 10;  // options-specified minimum contracted image size relative to 100% container
 				opts.maxSize = Math.round( 10 * (100 - (numPanels - 1) * (opts.minSize + opts.spacing))) / 10; // expanded image size relative to 100% container
@@ -293,7 +292,7 @@
 				offset = Math.round(offsets[i]*1000)/1000;
 				if (i === $panels.length - 1) {
 					size = 100 - offset;
-					style = sAlign + ':0;' + pDim + ':' + size + units + ";";
+					style = sAlign + ':0;' + pDim + ':' + size + $units + ";";
 				} else {
 					size = Math.round((prevOffset - offset - spacing)*1000)/1000;
 					style = pAlign + ':' + offset + $units + ';' + pDim + ':' + size + $units + ';';
@@ -302,7 +301,7 @@
 				offset = Math.round(offsets[i]);
 				if (i === $panels.length - 1) {
 					size = containerSize - offset;
-					style = sAlign + ':0;' + pDim + ':' + size + units + ";";
+					style = sAlign + ':0;' + pDim + ':' + size + $units + ";";
 				} else {
 					size = Math.round(prevOffset - offset - spacing);
 					style = pAlign + ':' + offset + $units + ';' + pDim + ':' + size + $units + ';';


### PR DESCRIPTION
I invite you to consider these additions to kwicks.js to make it scale with it's container.

As modified, this js file makes NO changes to the current kwicks behaviour when used with current settings - it only adds a feature triggered by a setting.

The enhancement is to add another setting option - "units" that defaults to 'px' but allows '%'
When in % mode, two other settings have a different meaning - size is maximum container size (max-width) in px and maxSize is maximum image size in px when displayed at 100% (max-width).  
In this mode, all widths and offsets are rendered as %.
(see last commit comment for details for this example.)
example:
container maximum 'size' = 950, image width at maximum 'maxSize' = 300, spacing = .3, units = '%'
rendered styles:
expanded width = 31.7%, unexpanded width (size) = 19.7% for 5 panels, collapsed width = 16.7%
unexpanded layout - 19.7% + .3% + 19.7% + .3% + 19.7% + .3% + 19.7% + .3% + 19.7%  = 99.7%
expanded layout - 16.7% + .3% + 16.7% + .3% + 31.7% + .3% + 16.7% + .3% + 16.7%  = 99.7%

css and html files need to be modified to demo this mode  - would you like that done in the current package / master branch or would you prefer to setup a "responsive" branch or leave this as a separate fork?

Duke
