### PR TITLE
Slideshow Kwicks at boot

### DIFF
--- a/examples/slideshow.html
+++ b/examples/slideshow.html
@@ -32,18 +32,12 @@
 		
 		<script type='text/javascript'>
 			$(function() {
-				var $slideshow = $('.kwicks').kwicks({
+				$('.kwicks').kwicks({
 					minSize : 20,
-					spacing : 5
+					spacing : 5,
+					behavior: "slideshow",
+					showSpeed: 2.5
 				});
-
-				var numSlides = $slideshow.children().length,
-					speed = 2000,
-					curSlide = 0;
-
-				setInterval(function() {
-					$slideshow.kwicks('expand', ++curSlide % numSlides);
-				}, speed);
 			});
 		</script>
 	</body>

--- a/jquery.kwicks.js
+++ b/jquery.kwicks.js
@@ -23,14 +23,15 @@
 				isVertical: false,
 				easing: undefined,
 				behavior: null,
-				autoResize: true
+				autoResize: true,
+				showSpeed: undefined
 			};
 			var o = $.extend(defaults, opts);
 
 			// validate and normalize options
 			if (o.minSize !== -1 && o.maxSize !== -1)
 				throw new Error('Kwicks options minSize and maxSize may not both be set');
-			if (o.behavior && o.behavior !== 'menu')
+			if (o.behavior && o.behavior !== 'menu' && o.behavior !== 'slideshow')
 				throw new Error('Unrecognized Kwicks behavior specified: ' + o.behavior);
 			$.each(['minSize', 'maxSize'], function(i, prop) {
 				var val = o[prop];
@@ -216,6 +217,7 @@
 		this.initStyles();
 		this.initBehavior();
 		this.initWindowResizeHandler();
+		this.initSlideShow();
 	};
 
 	/**
@@ -381,6 +383,11 @@
 					$(this).kwicks('select');
 				});
 				break;
+			case 'slideshow':
+				this.$panels.click(function(){
+					$(this).kwicks('select');
+				});
+				break;
 			default:
 				throw new Error('Unrecognized behavior option: ' + this.opts.behavior);
 		}
@@ -416,6 +423,26 @@
 			self.resize();			
 		}
 		$(window).on('resize', onResize);
+	};
+
+	/**
+	 * Initialize Slide Show behavior
+	 */
+	Kwick.prototype.initSlideShow = function() {
+		if (!this.opts.showSpeed || this.opts.behavior !== "slideshow") return;
+		if (isNaN(this.opts.showSpeed)) {
+			throw new Error('Invalid slideShow option (not a number): ' + this.opts.slideShow);
+		}
+
+		var self = this,
+			speed = parseInt(this.opts.showSpeed)*1000,
+			numSlides = this.$panels.length,
+			curSlide = 0;
+
+		clearInterval(this.slideShowInterval);
+		this.slideShowInterval = setInterval(function(){
+			self.expand(curSlide++ % numSlides);
+		},speed);
 	};
 
 	/**


### PR DESCRIPTION
Here an add to _kwicks_ behavior: **the slideshow**.
Based on your _examples/slideshow.html_ file, I've integrated this behavior within the kwicks initialize.
By adding these options on the kwicks init object:

`{
  behavior: 'slideshow',
  showSpeed: 3.2
}`

The kwicks will automatically boot on slideshow mode with a delay of 3.2 seconds between each slide.

Of course, the new behaviour _'slideshow'_ that let the user to select a panel but not to expand it, it's just a prototype.
Maybe we can discuss a better idea of what this behavior should do.
